### PR TITLE
queue-rollover

### DIFF
--- a/src/app/play-queue/play-queue.controller.js
+++ b/src/app/play-queue/play-queue.controller.js
@@ -25,6 +25,7 @@ class PlayQueueController {
         <td
             class="image"
             onclick="${angularThis}.playQueueService.play(${i})">
+          <span class="rollover" ></span>
           <img
               class="${(!item.icon) ? '' : 'hidden'}"
               ${(!item.icon) ? 'src="' + this.socketService.host + item.albumart + '"' : ''}

--- a/src/app/themes/volumio/play-queue/volumio-play-queue.scss
+++ b/src/app/themes/volumio/play-queue/volumio-play-queue.scss
@@ -26,17 +26,15 @@
     height: 45px;
     width: 45px;
     position: absolute;
-    z-index: 10;
-    &:hover {
-      background: rgba(0,0,0,.5);
-      -webkit-transition: .3s;
-      box-shadow: 0px 0px 2px #000;
-      &:before {
-        content: '\f04b';
-      }
-      &:active {
-        color: $volumio-green-color;
-      }
+  }
+  tr:hover span.rollover {
+    background: rgba(0,0,0,.3);
+    -webkit-transition: .3s;
+    &:before {
+      content: '\f04b';
+    }
+    &:active {
+      color: $volumio-green-color;
     }
   }
 }


### PR DESCRIPTION
Reintroduce the play icon when hovering over items in the play queue
from
https://github.com/volumio/Volumio2-UI/commit/5eb2fdeef4bd11fcaf33c10febef77ca82ba981d
that was overwritten in
https://github.com/volumio/Volumio2-UI/commit/e99653dd2c1da1e3d49dfec2e9a86f3516c2aee5