### PR TITLE
Hide hamburger menu for items of type spotify-category

### DIFF
--- a/src/app/browse/browse.controller.js
+++ b/src/app/browse/browse.controller.js
@@ -165,7 +165,7 @@ class BrowseController {
   }
 
   showHamburgerMenu(item) {
-    let ret = item.type === 'radio-favourites' || item.type === 'radio-category';
+    let ret = item.type === 'radio-favourites' || item.type === 'radio-category' || item.type === 'spotify-category';
     return !ret;
   }
 


### PR DESCRIPTION
Today's Spotify plugin pull request changes the item type value of top level Spotify browse categories to "spotify-category".  Disabling the display of the hamburger menu for items of this type.