### PR TITLE
Use the term Alias instead of Name

### DIFF
--- a/src/app/plugin/core-plugin/network-drives-plugin.html
+++ b/src/app/plugin/core-plugin/network-drives-plugin.html
@@ -31,7 +31,7 @@
 
       <table class="table" ng-if="networkDrives.infoShare">
         <tr>
-          <th><span translate="NETWORKFS.NAME"></span></th>
+          <th><span translate="NETWORKFS.ALIAS"></span></th>
           <th><span translate="NETWORKFS.PATH"></span></th>
           <th><span translate="NETWORKFS.MOUNTED"></span></th>
           <th><span translate="NETWORKFS.SIZE"></span></th>


### PR DESCRIPTION
When the drives are added the 'Name' field is called 'Alias'. Stick to that in the list of configured drives.