### PR TITLE
Make it clearer that sleep time is an offset

### DIFF
--- a/src/app/components/side-menu/elements/modal-sleep.controller.js
+++ b/src/app/components/side-menu/elements/modal-sleep.controller.js
@@ -8,12 +8,13 @@ class ModalSleepController {
     this.$log = $log;
     this.$translate = $translate;
 
+    this.timeType = 'offset';
     this.sleepTime = new Date();
     this.sleepTime.setHours(0, 0);
     this.enabled = false;
 
 
-    $translate(['SLEEP.POWER_OFF', 'SLEEP.STOP_MUSIC']).then(translations => {
+    $translate(['SLEEP.POWER_OFF', 'SLEEP.STOP_MUSIC', 'SLEEP.IN' /*, 'SLEEP.AT' */]).then(translations => {
         this.whenSleepSelect = [
           {
             val: 'stop',
@@ -24,12 +25,23 @@ class ModalSleepController {
             text: translations['SLEEP.POWER_OFF']
           }
         ];
+        this.whenSleepTimeTypeSelect = [
+          {
+            val: 'offset',
+            text: translations['SLEEP.IN']
+          },
+          {
+            val: 'absolute',
+            text: translations['SLEEP.AT']
+          }
+        ];
       });
     this.init();
   }
 
   setSleep() {
     let obj = {
+      timeType: this.timeType.val,
       enabled: this.enabled,
       time: this.sleepTime.getHours() + ':' + this.sleepTime.getMinutes(),
       action: this.action.val

--- a/src/app/components/side-menu/elements/modal-sleep.html
+++ b/src/app/components/side-menu/elements/modal-sleep.html
@@ -3,7 +3,7 @@
 </div>
 <div class="modal-body sleep">
   <div class="row">
-    <div class="col-sm-8">
+    <div class="col-sm-6">
       <h4 translate="COMMON.ACTION"></h4>
       <ui-select
           id="whenSleep"
@@ -23,7 +23,26 @@
         </ui-select-choices>
       </ui-select>
     </div>
-    <div class="col-sm-8">
+    <div class="col-sm-6">
+      <h4 translate="SLEEP.WHEN"></h4>
+      <ui-select
+          id="whenSleepTimeType"
+          ng-model="modal.timeType"
+          search-enabled="false"
+          append-to-body="false"
+          theme="bootstrap">
+      <ui-select-match
+          class="ui-select-match"
+          placeholder="">
+          <translate>SLEEP.IN</translate>
+      </ui-select-match>
+      <ui-select-choices
+          class="ui-select-choices"
+          repeat="item in modal.whenSleepTimeTypeSelect track by $index">
+        <div id="sleepTimeTypeOption-{{item.val}}" ng-bind-html="item.text"></div>
+      </ui-select-choices>
+    </div>
+    <div class="col-sm-6">
       <uib-timepicker
           ng-model="modal.sleepTime"
           ng-change="modal.timeChanged()"
@@ -32,7 +51,7 @@
           show-meridian="modal.showMeridian">
       </uib-timepicker>
     </div>
-    <div class="col-sm-8">
+    <div class="col-sm-6">
       <h4 translate="COMMON.ACTIVE"></h4>
       <input
           bs-switch

--- a/src/app/i18n/locale-en.json
+++ b/src/app/i18n/locale-en.json
@@ -173,6 +173,9 @@
     "NETWORK_NAME":"Network Name"
   },
   "SLEEP": {
+    "AT": "at",
+    "IN": "in",
+    "WHEN": "when",
     "POWER_OFF": "Power off",
     "STOP_MUSIC": "Stop music"
   },


### PR DESCRIPTION
To make it clearer that the sleep function is setting an offset from
the current time, insert the word 'in' between the action selector
and the time picker. This raises the possibility of using 'at' in
the same location and allowing absolute times to be set, so add a
little bit of code to support that but make it invisible for now.