### PR TITLE
Show elapsed time in same format as track length

### DIFF
--- a/src/app/services/player.service.js
+++ b/src/app/services/player.service.js
@@ -139,13 +139,10 @@ class PlayerService {
       hours = momentDuration.hours(),
       minutes = momentDuration.minutes(),
       seconds = momentDuration.seconds();
-    if (this.hours > 0) {
-      this.elapsedTimeString = hours + ':' + minutes + ':' +
-        ((seconds < 10) ? ('0' + seconds) : seconds);
-    } else {
-      this.elapsedTimeString = minutes + ':' +
-        ((seconds < 10) ? ('0' + seconds) : seconds);
-    }
+    // Track length is shown as mm:ss - do the same for elapsed time
+    minutes += hours*60;
+    this.elapsedTimeString = minutes + ':' +
+                             ((seconds < 10) ? ('0' + seconds) : seconds);
   }
 
   startSeek() {


### PR DESCRIPTION
See  volumio/Volumio2#1299 for the motivation. 
Tested on 2.201, patch on top of master (fd982d8d8ef564022e7ce352177cc750037884d4).
To simulate a very long track, artificially added 500 min to the minutes at line 143 - the resulting string displayed ok.
