### PR TITLE
pass service when removing from playlist

### DIFF
--- a/src/app/services/playlist.service.js
+++ b/src/app/services/playlist.service.js
@@ -36,7 +36,8 @@ class PlaylistService {
     this.$log.debug('removeFromPlaylist', item, playlist);
     this.socketService.emit('removeFromPlaylist', {
       name: playlist,
-      uri: item.uri
+      uri: item.uri,
+      service: (item.service || null)
     });
   }
 


### PR DESCRIPTION
This change is needed so that all music service plugins can add their stuff to a playlist and remove it from there.

This is related to my other PR:
- volumio/Volumio2#1355
- support in Youtube plugin: volumio/volumio-plugins#101 and volumio/volumio-plugins#102
