### PR TITLE
Fix name of constants file generated by newer gulp

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -58,7 +58,7 @@
     <script src="/app/lib/babel-polyfill/polyfill.min.js"></script>
     <script src="/app/lib/socket/socket.io-1.4.5.js"></script>
     <script src="/app/lib/sortable/sortable-1.4.2.js"></script>
-    <script src="/app/ngConstants.js"></script>
+    <script src="/app/volumio.constant.js"></script>
     <!-- endbuild -->
 
     <!-- build:js({.tmp/serve,.tmp/partials}) scripts/app.js -->


### PR DESCRIPTION
This PR is for #469 and changes the name of the included constants file to be in line with the newer gulp used to build the dist.