### PR TITLE
Fix path placeholders

### DIFF
--- a/src/app/i18n/locale-ca.json
+++ b/src/app/i18n/locale-ca.json
@@ -154,7 +154,7 @@
     "DELETE_DRIVE_CONFIRM":"Segur que la vols esborrar?",
     "PLACEHOLDER_NAME":"Nom",
     "PLACEHOLDER_IP_ADDRESS":"Adressa IP o nom",
-    "PLACEHOLDER_PATH_TO_SHARE":"Ruta/per/Compartir"
+    "PLACEHOLDER_PATH_TO_SHARE":"/Ruta/per/Compartir"
   },
   "NETWORK":{
     "NETWORK_STATUS":"Estat de la xarxa",

--- a/src/app/i18n/locale-cs.json
+++ b/src/app/i18n/locale-cs.json
@@ -154,7 +154,7 @@
     "DELETE_DRIVE_CONFIRM":"Opravdu chcete vymazat nastavení síťového disku?",
     "PLACEHOLDER_NAME":"Jméno",
     "PLACEHOLDER_IP_ADDRESS":"IP adresa nebo název NAS",
-    "PLACEHOLDER_PATH_TO_SHARE":"cesta/k/moji/hudbe"
+    "PLACEHOLDER_PATH_TO_SHARE":"/cesta/k/moji/hudbe"
   },
   "NETWORK":{
     "NETWORK_STATUS":"Stav sítě",

--- a/src/app/i18n/locale-da.json
+++ b/src/app/i18n/locale-da.json
@@ -135,7 +135,7 @@
     "DELETE_DRIVE_CONFIRM":"Vil du slette",
     "PLACEHOLDER_NAME":"Navn",
     "PLACEHOLDER_IP_ADDRESS":"NAS IP-adresse eller navn",
-    "PLACEHOLDER_PATH_TO_SHARE":"Sti/til/Share"
+    "PLACEHOLDER_PATH_TO_SHARE":"/Sti/til/Share"
   },
   "NETWORK":{
     "NETWORK_STATUS":"Netværksstatus",

--- a/src/app/i18n/locale-de.json
+++ b/src/app/i18n/locale-de.json
@@ -164,7 +164,7 @@
     "DELETE_DRIVE_CONFIRM":"Laufwerk wirklich löschen",
     "PLACEHOLDER_NAME":"Name des Netzwerklaufwerks",
     "PLACEHOLDER_IP_ADDRESS":"IP-Adresse oder Name des Netzwerklaufwerks",
-    "PLACEHOLDER_PATH_TO_SHARE":"Pfad/für/Freigabe"
+    "PLACEHOLDER_PATH_TO_SHARE":"/Pfad/für/Freigabe"
   },
   "NETWORK":{
     "NETWORK_STATUS":"Netzwerkstatus",

--- a/src/app/i18n/locale-en.json
+++ b/src/app/i18n/locale-en.json
@@ -164,7 +164,7 @@
     "DELETE_DRIVE_CONFIRM":"Do you want to delete",
     "PLACEHOLDER_NAME":"Name",
     "PLACEHOLDER_IP_ADDRESS":"NAS Ip Address or Name",
-    "PLACEHOLDER_PATH_TO_SHARE":"Path/to/Share"
+    "PLACEHOLDER_PATH_TO_SHARE":"/Path/to/Share"
   },
   "NETWORK":{
     "NETWORK_STATUS":"Network Status",

--- a/src/app/i18n/locale-es.json
+++ b/src/app/i18n/locale-es.json
@@ -164,7 +164,7 @@
     "DELETE_DRIVE_CONFIRM":"¿Quieres eliminar",
     "PLACEHOLDER_NAME":"Nombre",
     "PLACEHOLDER_IP_ADDRESS":"Dirección IP o Nombre",
-    "PLACEHOLDER_PATH_TO_SHARE":"Ruta/Del/Recurso"
+    "PLACEHOLDER_PATH_TO_SHARE":"/Ruta/Del/Recurso"
   },
   "NETWORK":{
     "NETWORK_STATUS":"Estado de la red",

--- a/src/app/i18n/locale-fi.json
+++ b/src/app/i18n/locale-fi.json
@@ -136,7 +136,7 @@
     "DELETE_DRIVE_CONFIRM":"Haluatko poistaa",
     "PLACEHOLDER_NAME":"Nimi",
     "PLACEHOLDER_IP_ADDRESS":"Verkkoaseman nimi tai IP",
-    "PLACEHOLDER_PATH_TO_SHARE":"Polku/jako"
+    "PLACEHOLDER_PATH_TO_SHARE":"/Polku/jako"
   },
   "NETWORK":{
     "NETWORK_STATUS":"Verkon tila",

--- a/src/app/i18n/locale-fr.json
+++ b/src/app/i18n/locale-fr.json
@@ -164,7 +164,7 @@
     "DELETE_DRIVE_CONFIRM":"Voulez vous vraiment effacer ?",
     "PLACEHOLDER_NAME":"Nom",
     "PLACEHOLDER_IP_ADDRESS":"Address IP du NAS ou Nom",
-    "PLACEHOLDER_PATH_TO_SHARE":"Chemin du partage"
+    "PLACEHOLDER_PATH_TO_SHARE":"/Chemin/du/partage"
   },
   "NETWORK":{
     "NETWORK_STATUS":"Etat du réseau",

--- a/src/app/i18n/locale-gr.json
+++ b/src/app/i18n/locale-gr.json
@@ -135,7 +135,7 @@
     "DELETE_DRIVE_CONFIRM":"Επιβεβαίωση διαγραφής μονάδας",
     "PLACEHOLDER_NAME":"Όνομα",
     "PLACEHOLDER_IP_ADDRESS":"Διεύθυνση IP ή όνομα NAS",
-    "PLACEHOLDER_PATH_TO_SHARE":"Διαδρομή/για/share"
+    "PLACEHOLDER_PATH_TO_SHARE":"/Διαδρομή/για/share"
   },
   "NETWORK":{
     "NETWORK_STATUS":"Κατάσταση δικτύου",

--- a/src/app/i18n/locale-hu.json
+++ b/src/app/i18n/locale-hu.json
@@ -136,7 +136,7 @@
     "DELETE_DRIVE_CONFIRM":"Biztos, hogy törölni akarod?",
     "PLACEHOLDER_NAME":"Név",
     "PLACEHOLDER_IP_ADDRESS":"NAS IP címe vagy neve",
-    "PLACEHOLDER_PATH_TO_SHARE":"megosztott/fájlok/útvonala"
+    "PLACEHOLDER_PATH_TO_SHARE":"/megosztott/fájlok/útvonala"
   },
   "NETWORK":{
     "NETWORK_STATUS":"Hálózat állapota",

--- a/src/app/i18n/locale-it.json
+++ b/src/app/i18n/locale-it.json
@@ -163,7 +163,7 @@
     "DELETE_DRIVE_CONFIRM":"Vuoi eliminare il disco",
     "PLACEHOLDER_NAME":"Nome",
     "PLACEHOLDER_IP_ADDRESS":"Indirizzo IP o Nome del NAS",
-    "PLACEHOLDER_PATH_TO_SHARE":"Indirizzo/della/Share"
+    "PLACEHOLDER_PATH_TO_SHARE":"/Indirizzo/della/Share"
   },
   "NETWORK":{
     "NETWORK_STATUS":"Stato della rete",

--- a/src/app/i18n/locale-ja.json
+++ b/src/app/i18n/locale-ja.json
@@ -156,7 +156,7 @@
      "DELETE_DRIVE_CONFIRM":"削除しますか",
      "PLACEHOLDER_NAME":"名前",
      "PLACEHOLDER_IP_ADDRESS":"NAS IP アドレスまたは名前",
-     "PLACEHOLDER_PATH_TO_SHARE":"共有パス"
+     "PLACEHOLDER_PATH_TO_SHARE":"/共有/パス"
    },
    "NETWORK":{
      "NETWORK_STATUS":"ネットワークの状態",

--- a/src/app/i18n/locale-ko.json
+++ b/src/app/i18n/locale-ko.json
@@ -151,7 +151,7 @@
     "DELETE_DRIVE_CONFIRM":"제거하시겠습니까?",
     "PLACEHOLDER_NAME":"이름",
     "PLACEHOLDER_IP_ADDRESS":"NAS IP 주소 또는 이름",
-    "PLACEHOLDER_PATH_TO_SHARE":"Path/to/Share"
+    "PLACEHOLDER_PATH_TO_SHARE":"/Path/to/Share"
   },
   "NETWORK":{
     "NETWORK_STATUS":"네트웍 상태",

--- a/src/app/i18n/locale-nl.json
+++ b/src/app/i18n/locale-nl.json
@@ -164,7 +164,7 @@
     "DELETE_DRIVE_CONFIRM":"De schijf echt wissen",
     "PLACEHOLDER_NAME":"Naam",
     "PLACEHOLDER_IP_ADDRESS":"NAS IP adres of Naam",
-    "PLACEHOLDER_PATH_TO_SHARE":"Pad/naar/Gedeelde Map"
+    "PLACEHOLDER_PATH_TO_SHARE":"/Pad/naar/Gedeelde Map"
   },
   "NETWORK":{
     "NETWORK_STATUS":"Netwerk status",

--- a/src/app/i18n/locale-no.json
+++ b/src/app/i18n/locale-no.json
@@ -137,7 +137,7 @@
     "DELETE_DRIVE_CONFIRM":"Vil du virkelig slette",
     "PLACEHOLDER_NAME":"Navn",
     "PLACEHOLDER_IP_ADDRESS":"NAS Ip adresse eller navn",
-    "PLACEHOLDER_PATH_TO_SHARE":"Katalog/til/resurs"
+    "PLACEHOLDER_PATH_TO_SHARE":"/Katalog/til/resurs"
   },
   "NETWORK":{
     "NETWORK_STATUS":"Nettverkstatus",

--- a/src/app/i18n/locale-pl.json
+++ b/src/app/i18n/locale-pl.json
@@ -135,7 +135,7 @@
     "DELETE_DRIVE_CONFIRM":"Czy chcesz usunąć",
     "PLACEHOLDER_NAME":"Nazwa",
     "PLACEHOLDER_IP_ADDRESS":"Adres IP Serwera NAS lub Nazwa",
-    "PLACEHOLDER_PATH_TO_SHARE":"Ścieżka do katalogu"
+    "PLACEHOLDER_PATH_TO_SHARE":"/Ścieżka/do/katalogu"
   },
   "NETWORK":{
     "NETWORK_STATUS":"Status Sieci",

--- a/src/app/i18n/locale-pt.json
+++ b/src/app/i18n/locale-pt.json
@@ -149,7 +149,7 @@
     "DELETE_DRIVE_CONFIRM":"Quer mesmo apagar",
     "PLACEHOLDER_NAME":"Nome",
     "PLACEHOLDER_IP_ADDRESS":"Endereço IP ou Nome da NAS",
-    "PLACEHOLDER_PATH_TO_SHARE":"Endereço/até á/Partilha"
+    "PLACEHOLDER_PATH_TO_SHARE":"/Endereço/até/á/Partilha"
   },
   "NETWORK":{
     "NETWORK_STATUS":"Estado da Rede",

--- a/src/app/i18n/locale-ru.json
+++ b/src/app/i18n/locale-ru.json
@@ -136,7 +136,7 @@
     "DELETE_DRIVE_CONFIRM":"Вы действительно хотите удалить?",
     "PLACEHOLDER_NAME":"Имя",
     "PLACEHOLDER_IP_ADDRESS":"IP адрес NAS или Имя",
-    "PLACEHOLDER_PATH_TO_SHARE":"Путь/к/шаре"
+    "PLACEHOLDER_PATH_TO_SHARE":"/Путь/к/шаре"
   },
   "NETWORK":{
     "NETWORK_STATUS":"Статус сети",

--- a/src/app/i18n/locale-sk.json
+++ b/src/app/i18n/locale-sk.json
@@ -163,7 +163,7 @@
     "DELETE_DRIVE_CONFIRM":"Opravdu chcete vymazať nastavenie",
     "PLACEHOLDER_NAME":"Meno",
     "PLACEHOLDER_IP_ADDRESS":"IP adresa alebo názov NAS",
-    "PLACEHOLDER_PATH_TO_SHARE":"cesta/k/hudbe"
+    "PLACEHOLDER_PATH_TO_SHARE":"/cesta/k/hudbe"
   },
   "NETWORK":{
     "NETWORK_STATUS":"Stav siete",

--- a/src/app/i18n/locale-sv.json
+++ b/src/app/i18n/locale-sv.json
@@ -135,7 +135,7 @@
     "DELETE_DRIVE_CONFIRM":"Vill du radera",
     "PLACEHOLDER_NAME":"Namn",
     "PLACEHOLDER_IP_ADDRESS":"NAS Ipadress eller Namn",
-    "PLACEHOLDER_PATH_TO_SHARE":"Sökväg/till/Share"
+    "PLACEHOLDER_PATH_TO_SHARE":"/Sökväg/till/Share"
   },
   "NETWORK":{
     "NETWORK_STATUS":"Nätverks Status",

--- a/src/app/i18n/locale-tr.json
+++ b/src/app/i18n/locale-tr.json
@@ -164,7 +164,7 @@
     "DELETE_DRIVE_CONFIRM":"Silmek istiyormusunuz?",
     "PLACEHOLDER_NAME":"Adı",
     "PLACEHOLDER_IP_ADDRESS":"NAS Ip Adresi veya Adı",
-    "PLACEHOLDER_PATH_TO_SHARE":"PAylaşım Yolu - Path/to/Share"
+    "PLACEHOLDER_PATH_TO_SHARE":"/PAylaşım/Yolu"
   },
   "NETWORK":{
     "NETWORK_STATUS":"Ağ Durumu",

--- a/src/app/i18n/locale-ua.json
+++ b/src/app/i18n/locale-ua.json
@@ -136,7 +136,7 @@
     "DELETE_DRIVE_CONFIRM":"Дійсно хочете видалити?",
     "PLACEHOLDER_NAME":"Назва",
     "PLACEHOLDER_IP_ADDRESS":"IP-адреса або назва",
-    "PLACEHOLDER_PATH_TO_SHARE":"Шлях до загальнодоступних тек"
+    "PLACEHOLDER_PATH_TO_SHARE":"/Шлях/до/загальнодоступних/тек"
   },
   "NETWORK":{
     "NETWORK_STATUS":"Стан мережі",

--- a/src/app/i18n/locale-zh.json
+++ b/src/app/i18n/locale-zh.json
@@ -139,7 +139,7 @@
     "DELETE_DRIVE_CONFIRM":"您确定要删除吗",
     "PLACEHOLDER_NAME":"名称",
     "PLACEHOLDER_IP_ADDRESS":"NAS Ip地址或名称",
-    "PLACEHOLDER_PATH_TO_SHARE":"路径/到/共享"
+    "PLACEHOLDER_PATH_TO_SHARE":"/路径/到/共享"
   },
   "NETWORK":{
     "NETWORK_STATUS":"网络状态",

--- a/src/app/i18n/locale-zh_TW.json
+++ b/src/app/i18n/locale-zh_TW.json
@@ -164,7 +164,7 @@
     "DELETE_DRIVE_CONFIRM":"您確定要刪除嗎",
     "PLACEHOLDER_NAME":"名稱",
     "PLACEHOLDER_IP_ADDRESS":"NAS Ip地址或名稱",
-    "PLACEHOLDER_PATH_TO_SHARE":"路徑/到/共享"
+    "PLACEHOLDER_PATH_TO_SHARE":"/路徑/到/共享"
   },
   "NETWORK":{
     "NETWORK_STATUS":"網路狀態",


### PR DESCRIPTION
Mounting an nfs share requires a starting `/`. Updated the placeholder text to reflect that requirement.