### PR TITLE
Extend alarm-clock module : weekday selection

### DIFF
--- a/src/app/components/side-menu/elements/modal-alarm-clock.html
+++ b/src/app/components/side-menu/elements/modal-alarm-clock.html
@@ -18,6 +18,17 @@
           show-meridian="modal.showMeridian">
       </uib-timepicker>
     </div>
+    <div class="col-xs-12 col-sm-6">
+      <div class="btn-group">
+        <label class="btn btn-primary" ng-model="alarm.monday" uib-btn-checkbox>{{'ALARM.MONDAY' | translate}}</label>
+        <label class="btn btn-primary" ng-model="alarm.tuesday" uib-btn-checkbox>{{'ALARM.TUESDAY' | translate}}</label>
+        <label class="btn btn-primary" ng-model="alarm.wednesday" uib-btn-checkbox>{{'ALARM.WEDNESDAY' | translate}}</label>
+        <label class="btn btn-primary" ng-model="alarm.thursday" uib-btn-checkbox>{{'ALARM.THURSDAY' | translate}}</label>
+        <label class="btn btn-primary" ng-model="alarm.friday" uib-btn-checkbox>{{'ALARM.FRIDAY' | translate}}</label>
+        <label class="btn btn-primary" ng-model="alarm.saturday" uib-btn-checkbox>{{'ALARM.SATURDAY' | translate}}</label>
+        <label class="btn btn-primary" ng-model="alarm.sunday" uib-btn-checkbox>{{'ALARM.SUNDAY' | translate}}</label>
+      </div>
+    </div>
     <div class="col-xs-12 col-sm-6 pull-down">
       <input
           bs-switch

--- a/src/app/i18n/locale-en.json
+++ b/src/app/i18n/locale-en.json
@@ -219,7 +219,14 @@
     "OFF": "Off"
   },
   "ALARM": {
-    "CRATE_PLAYLIST_FIRST": "In order to use Alarm Clock, you must create at least one Playlist first"
+    "CRATE_PLAYLIST_FIRST": "In order to use Alarm Clock, you must create at least one Playlist first",
+    "MONDAY":"Monday",
+    "TUESDAY":"Tuesday",
+    "WEDNESDAY":"Wednesday",
+    "THURSDAY":"Thursday",
+    "FRIDAY":"Friday",
+    "SATURDAY":"Saturday",
+    "SUNDAY":"Sunday"
   },
   "MULTIDEVICE": {
     "EDIT_GROUPS": "Edit groups",

--- a/src/app/i18n/locale-fr.json
+++ b/src/app/i18n/locale-fr.json
@@ -219,7 +219,14 @@
     "OFF": "Stop"
   },
   "ALARM": {
-    "CRATE_PLAYLIST_FIRST": "Avant de pouvoir utiliser l'alarme, vous devez créer au moins une playlist"
+    "CRATE_PLAYLIST_FIRST": "Avant de pouvoir utiliser l'alarme, vous devez créer au moins une playlist",
+    "MONDAY":"Lundi",
+    "TUESDAY":"Mardi",
+    "WEDNESDAY":"Mercredi",
+    "THURSDAY":"Jeudi",
+    "FRIDAY":"Vendredi",
+    "SATURDAY":"Samedi",
+    "SUNDAY":"Dimanche"
   },
    "MULTIDEVICE": {
     "EDIT_GROUPS": "Editer les groupes",


### PR DESCRIPTION
Hi,
I told you about this PR in June, well I was quite busy.. I've finally find some time to do it..

I've add some options to the alarm clock feature.
The idea here is to be able to choose for which weekdays alarm has to be enable.

I've also made a PR for Volumio : https://github.com/volumio/Volumio2/pull/1640

This is my first contribution, I tried to respect your code style, be nice :)