### PR TITLE
Correctly scale non-square library cover images

### DIFF
--- a/src/app/themes/volumio/browse/volumio-browse.scss
+++ b/src/app/themes/volumio/browse/volumio-browse.scss
@@ -146,6 +146,7 @@
     img {
       width: 45px;
       height: 45px;
+      object-fit: cover;
     }
   }
 


### PR DESCRIPTION
I thought I'd start contributing with a very small, safe change before I jump into some much larger, more impactful PRs.

Fixes a minor UI glitch that causes folder/track/artist thumbnail images to be displayed stretched to the wrong proportions when a non-square image is used.

The solution is a very simple CSS update that will cause non-square images to be scaled with correct proportions, cropping the image instead of stretching it. `object-fit` is supported in most browsers, but browsers that don't support it will simply ignore the new CSS rule. (See the [CSS Tricks article](https://css-tricks.com/almanac/properties/o/object-fit/) for more about this CSS rule)

**Before:**

![thumbnail-fix-before](https://user-images.githubusercontent.com/5931636/50924441-7c2bf580-1447-11e9-8f13-39ee1cdcf5bc.png)

**After:**

![thumbnail-fix-after](https://user-images.githubusercontent.com/5931636/50924459-83eb9a00-1447-11e9-9e7b-665e5b9baeaf.png)