### PR TITLE
Add radio button group element to plugin config page

### DIFF
--- a/src/app/plugin/components/plugin-component.html
+++ b/src/app/plugin/components/plugin-component.html
@@ -47,6 +47,12 @@
 
                     <input ng-switch-when="switch" id="{{item.id}}" bs-switch ng-model="item.value" type="checkbox" switch-size="medium" switch-animate="false"
                       switch-on-text="On" switch-off-text="Off" ng-true-value="true" ng-false-value="false">
+                    
+                    <div ng-switch-when="radio" id="{{item.id}}" plugin-attributes="item.attributes" ng-model="item.value">
+                      <div ng-repeat="option in item.options track by $index">
+                          <input name="{{option.name}}" ng-model="item.value" type="radio" value="{{option.value}}"><label>{{option.label}}</label>
+                      </div>
+                    </div>
 
                     <div ng-switch-when="select">
                       <ui-select id="{{item.id}}" ng-model="item.value" search-enabled="false" ng-readonly="true" append-to-body="true" theme="bootstrap">


### PR DESCRIPTION
This PR adds the ability to use a group of radio buttons on Plugin config pages.

Can be used as follows in a plugin UIConfig.json file:

       {
          "id": "myRadioId",
          "element": "radio",
          "options": [
            {
              "label":"TRANSLATE.OPTION_ONE",
              "name": "optionOne",
              "value": "1"
            },
            {
              "label":"TRANSLATE.OPTION_TWO",
              "name": "optionTwo",
              "value": "2"
            }
          ],
          "value": "1",
          "label": "TRANSLATE.MY_RADIO_LABEL"
        }

When the section is saved the value returned for the element will be the value of the selected option.

myplugin.prototype.setUIConfig = function (data) {
  config.set('myConfigItem', data['myRadioId']);
}

Setting the value of the radio element in the plugin controller will result in the correct radio option being selected when the plugin config page is loaded.

myplugin.prototype.getUIConfig = function () {
  var lang_code = this.commandRouter.sharedVars.get('language_code');
  return this.commandRouter.i18nJson(__dirname + '/i18n/strings_' + lang_code + '.json',
      __dirname + '/i18n/strings_en.json',
      __dirname + '/UIConfig.json')
      .then(function (uiconf) {
       // radio button group element
        uiconf.sections[0].content[0].value = config.get('myConfigItem');
        return uiconf;
      })
      .fail(function () {
        libQ.reject(new Error());
      });
};