### PR TITLE
Fix iOS full screen mode when saving the url to home screen.

### DIFF
--- a/src/app/themes/volumio/assets/variants/volumio/manifest.json
+++ b/src/app/themes/volumio/assets/variants/volumio/manifest.json
@@ -1,5 +1,6 @@
 {
    "name":"Volumio",
+   "display": "standalone",
    "icons":[
       {
          "src":"app\/themes\/volumio\/assets\/variants\/volumio\/touch-icons\/android-chrome-36x36.png",

--- a/src/app/themes/volumio3/assets/variants/volumio/manifest.json
+++ b/src/app/themes/volumio3/assets/variants/volumio/manifest.json
@@ -1,5 +1,6 @@
 {
    "name":"Volumio",
+   "display": "standalone",
    "icons":[
       {
          "src":"app\/themes\/volumio\/assets\/variants\/volumio\/touch-icons\/android-chrome-36x36.png",

--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,6 @@
     <base href="/">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <link rel="shortcut icon" type="image/png" ng-href="{{favicon}}"/>
-    <link rel="manifest" ng-href="{{variantAssetsUrl}}/manifest.json">
 
     <link rel="apple-touch-icon" sizes="57x57" ng-href="{{touchIconsUrl}}/apple-touch-icon-57x57.png">
     <link rel="apple-touch-icon" sizes="60x60" ng-href="{{touchIconsUrl}}/apple-touch-icon-60x60.png">
@@ -28,7 +27,10 @@
     <meta name="apple-mobile-web-app-title" content="@APP_NAME">
     <meta name="theme-color" content="@BAR_COLOR">
     <meta name="apple-mobile-web-app-capable" content="yes"/>
+    <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="@BAR_COLOR">
+
+    <link rel="manifest" ng-href="{{variantAssetsUrl}}/manifest.json">
 
     <!-- build:css({.tmp/serve,src}) styles/vendor.css -->
     <!-- bower:css -->


### PR DESCRIPTION
This adds an entry to `manifest.json`, which now supersedes the meta tags for iOS 12+

Untested on Android. It would be great for someone to verify I at least didn't break functionality.