### PR TITLE
Update karma to avoid a deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "http-proxy-middleware": "~0.0.5",
     "jshint-loader": "~0.8.3",
     "jshint-stylish": "~2.0.0",
-    "karma": "~0.12.36",
+    "karma": "^3.1.4",
     "karma-jasmine": "~0.3.5",
     "karma-ng-html2js-preprocessor": "~0.1.2",
     "karma-phantomjs-launcher": "~1.0.0",


### PR DESCRIPTION
The warning with 0.12.36 was
  DeprecationWarning: process.EventEmitter is deprecated.
  Use require('events') instead.
It goes away with karma ^1.0, ^2.0 or ^3.0.
The system doesn't build with 4.x.