### PR TITLE
Make it possible for contributors to run deploy.sh before sending PRs

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e # exit with nonzero exit code if anything fails
 
+# These variables are set by CI builds.
+if [ ! -n "$GH_TOKEN" ] && [ ! -n "$GH_REF" ]; then
+    # Assume a test build, pushing to a contoributor's forked repository
+    myorigin=$(git config --get remote.origin.url)
+fi
+
 # VOLUMIO THEME
 # clear and re-create the dist directory
 rm -rf dist || exit 0;
@@ -25,7 +31,12 @@ git add .
 git commit -m "Deploy to Dist Branch"
 
 # Force push from the current repo's master branch to the dist branch for deployment
-git push --force --quiet "https://${GH_TOKEN}@${GH_REF}" master:dist > /dev/null 2>&1
+if [ -n "$myorigin" ]; then
+    git add remote origin "$myorigin"
+    git push --force origin master:dist
+else
+    git push --force --quiet "https://${GH_TOKEN}@${GH_REF}" master:dist > /dev/null 2>&1
+fi
 
 cd ..
 # VOLUMIO3 THEME
@@ -52,4 +63,9 @@ git add .
 git commit -m "Deploy to Dist3 Branch"
 
 # Force push from the current repo's master branch to the dist branch for deployment
-git push --force --quiet "https://${GH_TOKEN}@${GH_REF}" master:dist3 > /dev/null 2>&1
+if [ -n "$myorigin" ]; then
+    git add remote origin "$myorigin"
+    git push --force origin master:dist3
+else
+    git push --force --quiet "https://${GH_TOKEN}@${GH_REF}" master:dist3 > /dev/null 2>&1
+fi


### PR DESCRIPTION
Not sure how this will be received, but it seems useful to enable people to run the same script that CI does before submitting PRs, to make sure it exits cleanly. To be an exact simulation of what CI does it does require the user to have their master tracking branch up to date with upstream's (and the same nodejs version), but it should be close enough to catch silly errors.