### PR TITLE
Fix next / prev functions while playing webradio (1/2)

### DIFF
--- a/src/app/services/player.service.js
+++ b/src/app/services/player.service.js
@@ -85,16 +85,12 @@ class PlayerService {
   }
 
   shuffle() {
-    if (this.state.trackType !== 'webradio') {
       this.$log.debug(!this.state.random);
       this.socketService.emit('setRandom', {value: !this.state.random});
-    }
   }
 
   repeatAlbum(repeat,repeatSingle) {
-    if (this.state.trackType !== 'webradio') {
       this.socketService.emit('setRepeat', {value: repeat, repeatSingle: repeatSingle});
-    }
   }
 
   rebuildSpopLibrary() {

--- a/src/app/services/player.service.js
+++ b/src/app/services/player.service.js
@@ -69,15 +69,11 @@ class PlayerService {
   }
 
   prev() {
-    if (this.state.trackType !== 'webradio') {
       this.socketService.emit('prev');
-    }
   }
 
   next() {
-    if (this.state.trackType !== 'webradio') {
       this.socketService.emit('next');
-    }
   }
 
   skipBackwards() {


### PR DESCRIPTION
This PR fix next / prev functions while playing webradio !

I tested the modifications suggested in this post below and the next / prev functions work correctly!
https://github.com/volumio/Volumio2/issues/1122

To fix the problem a first modification is necessary in 
Volumio2-UI/src/app/services/player.service.js

```
@@ -69,15 +69,11 @@ class PlayerService {
  }

  prev() {
   - if (this.state.trackType !== 'webradio') {
      this.socketService.emit('prev');
   - }
  }

  next() {
   - if (this.state.trackType !== 'webradio') {
      this.socketService.emit('next');
   - }
  }


@@ -89,16 +85,12 @@ class PlayerService {
  }

  shuffle() {
   - if (this.state.trackType !== 'webradio') {
      this.$log.debug(!this.state.random);
      this.socketService.emit('setRandom', {value: !this.state.random});
   - }
  }

  repeatAlbum(repeat,repeatSingle) {
   - if (this.state.trackType !== 'webradio') {
      this.socketService.emit('setRepeat', {value: repeat, repeatSingle: repeatSingle});
   - }
  }
```

Changes must be coupled with another from main volumio2 in 
Volumio2/app/statemachine.js

PR link : [volumio/Volumio2/pull/1880]

hoping it will be useful !