### PR TITLE
Format the share path function of the fstype

### DIFF
--- a/src/app/plugin/core-plugin/network-drives-plugin.controller.js
+++ b/src/app/plugin/core-plugin/network-drives-plugin.controller.js
@@ -96,6 +96,17 @@ class NetworkDrivesPluginController {
     this.initService();
   }
 
+  fullShareName(drive){
+    switch (drive.fstype) {
+      case 'nfs':
+        return drive.ip + ':' + drive.path;
+      case 'cifs':
+        return '\\\\' + drive.ip + '\\' + drive.path;
+      default:
+        throw 'Unknown drive fstype ' + drive.fstype;
+    }
+  }
+
   registerListner() {
     this.socketService.on('pushListShares', (data) => {
       this.$log.debug('infoShare', data);

--- a/src/app/plugin/core-plugin/network-drives-plugin.html
+++ b/src/app/plugin/core-plugin/network-drives-plugin.html
@@ -44,7 +44,7 @@
             {{drive.name}}
           </td>
           <td ng-if="!networkDrives.matchmediaService.isPhone">
-            \\{{drive.ip}}\{{drive.path}}
+            {{networkDrives.fullShareName(drive)}}
           </td>
           <td>
             <i class="fa fa-check true" ng-if="drive.mounted"></i>


### PR DESCRIPTION
In the source settings, when we use a NFS, the format of the path is not "NFS style".
Adapt the format of the path regarding the fstype