### PR TITLE
Tabbed Panel in "Appearance Settings" for Background image and color section

### DIFF
--- a/src/app/i18n/locale-de.json
+++ b/src/app/i18n/locale-de.json
@@ -1,14 +1,17 @@
 {
   "UI_SETTINGS": {
-    "THEME_SETTINGS": "Hintergrundeinstellungen",
-    "UPLOAD_BACKGROUND": "Neuen Hintergrund hochladen",
-    "UPLOAD_BACKGROUND_FILE": "Klicken und Hintergrund auswählen oder Datei hier ablegen",
+    "THEME_SETTINGS": "Hintergrundbild",
+    "UPLOAD_BACKGROUND": "Neues Hintergrundbild hochladen",
+    "UPLOAD_BACKGROUND_FILE_BTN": "Hintergrundbild auswählen",
+    "UPLOAD_BACKGROUND_FILE_DRAG": "Oder Bilddatei in den Bereich ziehen",
     "UPLOAD_PROGRESS": "Fortschritt:",
-    "SELECT_BACKGROUND": "Hintergrund auswählen",
-    "SELECT_BACKGROUND_COLOR": "Hintergrundfarbe auswählen",
-    "APPLY_BACKGROUND": "Hintergrund auswählen",
-    "APPLY_BACKGROUND_COLOR": "Hintergrundfarbe auswählen",
-    "DELETE_BACKGROUND": "Hintergrund löschen"
+    "SELECT_BACKGROUND": "Hintergrundbild auswählen",
+    "SELECT_BACKGROUND_COLOR": "Einheitliche Farbe als Hintergrund auswählen",
+    "APPLY_BACKGROUND": "Hintergrundbild auswählen",
+    "APPLY_BACKGROUND_COLOR": "Farbe festlegen",
+    "DELETE_BACKGROUND": "Hintergrundbild löschen",
+    "TAB_BACKGROUND_IMAGE":"Bild",
+    "TAB_BACKGROUND_SOLIDCOLOR":"Farbe"
   },
   "COMMON": {
     "SAVE": "Speichern",

--- a/src/app/i18n/locale-en.json
+++ b/src/app/i18n/locale-en.json
@@ -2,13 +2,16 @@
   "UI_SETTINGS": {
     "THEME_SETTINGS": "Theme Settings",
     "UPLOAD_BACKGROUND": "Upload new background",
-    "UPLOAD_BACKGROUND_FILE": "Click and select new background or drop it here.",
+    "UPLOAD_BACKGROUND_FILE_BTN": "Click and select new background",
+    "UPLOAD_BACKGROUND_FILE_DRAG": "Or drop a new background image here",
     "UPLOAD_PROGRESS": "Upload progress:",
     "SELECT_BACKGROUND": "Select background",
-    "SELECT_BACKGROUND_COLOR": "Select background color",
+    "SELECT_BACKGROUND_COLOR": "Select a solid color as a background",
     "APPLY_BACKGROUND": "Apply background",
     "APPLY_BACKGROUND_COLOR": "Apply background color",
-    "DELETE_BACKGROUND": "Delete background"
+    "DELETE_BACKGROUND": "Delete background",
+    "TAB_BACKGROUND_IMAGE":"Image",
+    "TAB_BACKGROUND_SOLIDCOLOR":"Solid Color"
   },
   "COMMON": {
     "SAVE": "Save",

--- a/src/app/plugin/core-plugin/ui-settings-plugin.html
+++ b/src/app/plugin/core-plugin/ui-settings-plugin.html
@@ -1,35 +1,17 @@
 <div id="uiSettings" ng-controller="UiSettingsPluginController as uiSettingsPlugin"
-    class="panel panel-default">
-  <div class="panel-heading">
-    <h3 class="panel-title"><i class="fa fa-paint-brush"></i>
-      <span translate="UI_SETTINGS.THEME_SETTINGS"></span>
-    </h3>
-  </div>
-  <div class="panel-body">
-    <h4 class="sectionDescription" translate="UI_SETTINGS.UPLOAD_BACKGROUND_FILE"></h4>
-    <div ng-if="!uiSettingsPlugin.uploadPercentage">
-      <div
-          class="uploadDroppableArea"
-          ngf-drop="uiSettingsPlugin.uploadBackground()"
-          ngf-select="uiSettingsPlugin.uploadBackground()"
-          ngf-drag-over-class="'dragover'"
-          ng-model="uiSettingsPlugin.backgroundFile"
-          name="plugin">
-        <span translate="UI_SETTINGS.UPLOAD_BACKGROUND_FILE"></span>
-      </div>
-    </div>
+class="panel panel-default">
+<div class="panel-heading">
+<h3 class="panel-title"><i class="fa fa-paint-brush"></i>
+  <span translate="UI_SETTINGS.THEME_SETTINGS"></span>
+</h3>
+</div>
+<div class="panel-body">
 
-    <div id="installProgressBar" ng-if="uiSettingsPlugin.uploadPercentage > 0">
-      <h3 translate="UI_SETTINGS.UPLOAD_BACKGROUND_FILE"></h3>
-      <uib-progressbar
-          class="progress-striped active"
-          value="uiSettingsPlugin.uploadPercentage"
-          type="default">{{uiSettingsPlugin.uploadPercentage}}%
-      </uib-progressbar>
-    </div>
+<!-- Tabbed panel: Background image or color -->
+<uib-tabset active="pluginManager.activeTab">
 
-    <hr>
-
+  <!-- Tab 1: Select or upload image -->
+  <uib-tab index="0" heading="{{'UI_SETTINGS.TAB_BACKGROUND_IMAGE' | translate}}">
     <h4 class="sectionDescription" translate="UI_SETTINGS.SELECT_BACKGROUND"></h4>
     <div id="backgroundSelector" class="row">
       <div class="col-sm-6"
@@ -71,6 +53,31 @@
 
     <hr>
 
+    <h4 class="sectionDescription" translate="UI_SETTINGS.UPLOAD_BACKGROUND"></h4>
+    <div ng-if="!uiSettingsPlugin.uploadPercentage">
+      <div
+          class="uploadDroppableArea"
+          ngf-drop="uiSettingsPlugin.uploadBackground()"
+          ngf-select="uiSettingsPlugin.uploadBackground()"
+          ngf-drag-over-class="'dragover'"
+          ng-model="uiSettingsPlugin.backgroundFile"
+          name="plugin">
+        <btn class="btn btn-info" translate="UI_SETTINGS.UPLOAD_BACKGROUND_FILE_BTN"></btn><br><br><span><i class="fa fa-hand-pointer-o"></i> - {{ 'UI_SETTINGS.UPLOAD_BACKGROUND_FILE_DRAG' | translate }}</span>
+      </div>
+    </div>
+
+  <div id="installProgressBar" ng-if="uiSettingsPlugin.uploadPercentage > 0">
+    <h3 translate="UI_SETTINGS.UPLOAD_BACKGROUND_FILE"></h3>
+    <uib-progressbar
+        class="progress-striped active"
+        value="uiSettingsPlugin.uploadPercentage"
+        type="default">{{uiSettingsPlugin.uploadPercentage}}%
+    </uib-progressbar>
+  </div>
+  </uib-tab>
+
+  <!-- Tab 2: Select or specify a solid color -->
+  <uib-tab index="1" heading="{{'UI_SETTINGS.TAB_BACKGROUND_SOLIDCOLOR' | translate}}">
     <h4 class="sectionDescription" translate="UI_SETTINGS.SELECT_BACKGROUND_COLOR"></h4>
     <div id="backgroundColorSelector" class="row">
       <div class="col-xs-24" id="colorPalette">
@@ -101,5 +108,8 @@
         </div>
       </div>
     </div>
-  </div>
+  </uib-tab>
+
+</uib-tabset>
+</div>
 </div>


### PR DESCRIPTION
Setting for Background Image or Background panel is now wrapped in a tabbed panel.
"Click to select Image or drag here" string has been replaced by 2 seperate strings which are now better represented in the UI.