### PR TITLE
Fix spacing of hyphen in track info bar - part 2

### DIFF
--- a/src/app/themes/volumio3/components/track-info/volumio3-track-info.html
+++ b/src/app/themes/volumio3/components/track-info/volumio3-track-info.html
@@ -32,7 +32,7 @@
 
         <!--<span class='trackInfo-divider'>&nbsp</span>-->
 
-        <span id="trackInfo-album" ng-if="trackInfo.playerService.state.album" title="{{'COMMON.ALBUM' | translate}}"> - {{trackInfo.playerService.state.album}}
+        <span id="trackInfo-album" ng-if="trackInfo.playerService.state.album" title="{{'COMMON.ALBUM' | translate}}">{{trackInfo.playerService.state.album}}
         </span>
     </div>
 

--- a/src/app/themes/volumio3/components/track-info/volumio3-track-info.scss
+++ b/src/app/themes/volumio3/components/track-info/volumio3-track-info.scss
@@ -73,6 +73,9 @@
       }
     }
 
+    #trackInfo-album:before {
+      content: "\00a0\2010\00a0";
+    }
     #trackInfo-album{
       color: $theme-text-light-color;
     }


### PR DESCRIPTION
Instead of a hyphen in HTML, it is now dynamically inserted before the **trackInfo-album**-element. There's also spaces surrounding the hyphen.

See this previous commit: 55629ce46a9e02affeb52bf5b33c45dc9236ce88