### PR TITLE
#826 Fix track duration alignment for mixed one and two digit minutes

### DIFF
--- a/src/app/themes/volumio3/browse-music/components/music-item.scss
+++ b/src/app/themes/volumio3/browse-music/components/music-item.scss
@@ -134,6 +134,7 @@
 .item__duration {
     padding: 0 8px;
     min-width: 64px;
+    text-align: right;
 }
 
 .item__actions {


### PR DESCRIPTION
Trivial CSS fix

Closes #826 